### PR TITLE
Add "-lm" to line 72 to solve issue #2

### DIFF
--- a/llvm-passes/wrapper/collab_fuzz_wrapper.in
+++ b/llvm-passes/wrapper/collab_fuzz_wrapper.in
@@ -69,6 +69,7 @@ rt_libs = {
             "-Wl,--whole-archive",
             "@INST_COUNT_WRAPPER_RTLIB_PATH@",
             "-Wl,--no-whole-archive",
+            "-lm",
         ],
         [],
     ),


### PR DESCRIPTION
Update collab_fuzz_wrapper.in and add "-lm" to line 72 to solve the build error caused by the missing link command.